### PR TITLE
remove patch rpath option from `lib4bin`

### DIFF
--- a/appimage/deb_to_appimage.sh
+++ b/appimage/deb_to_appimage.sh
@@ -31,7 +31,7 @@ wget -nc --retry-connrefused --tries=5  "${LIB4BIN}" -O /tmp/lib4bin || true
 cp /tmp/lib4bin ./lib4bin
 
 chmod +x ./lib4bin
-./lib4bin -p -v -r -s -k ./usr/bin/wayvr_dashboard \
+./lib4bin -p -v -s -k ./usr/bin/wayvr_dashboard \
         /usr/lib/x86_64-linux-gnu/libGL* \
         /usr/lib/x86_64-linux-gnu/libEGL* \
         /usr/lib/x86_64-linux-gnu/libvulkan* \


### PR DESCRIPTION
We found out this often breaks libraries, specially hardware acceleration with nvidia users, it also causes assertion errors with gtk3. 

This feature actually isn't needed. See explanations: 

https://github.com/probonopd/PrusaSlicer.AppImage/pull/2
https://github.com/Rosalie241/RMG/pull/345