### PR TITLE
update appimage to use uruntime, add zsync updates support. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 'latest'
-    - run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev file binutils patchelf findutils grep sed coreutils strace
+    - run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev file binutils patchelf findutils grep sed coreutils strace zsync
     - run: rustup update stable && rustup default stable
     - run: npm install
     - run: npm run tauri build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: wayvr_dashboard-x86_64.AppImage
-        path: ./appimage/wayvr_dashboard.AppImage
+        path: ./appimage/wayvr_dashboard.AppImage*

--- a/appimage/deb_to_appimage.sh
+++ b/appimage/deb_to_appimage.sh
@@ -8,6 +8,7 @@ REPO_DIR="${SCRIPT_DIR}/../"
 
 LIB4BIN="https://raw.githubusercontent.com/VHSgunzo/sharun/9a6124a82595a835b07ea7fad7301be736e5a39b/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-${ARCH}"
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 
 cd "${SCRIPT_DIR}"
 
@@ -60,9 +61,16 @@ chmod +x ./uruntime
 # enable this if you want to keep the mount point and change block size to '-S26'
 #sed -i 's|URUNTIME_MOUNT=[0-9]|URUNTIME_MOUNT=0|' ./uruntime
 
+echo "Adding update information \"$UPINFO\" to runtime..."
+./uruntime --appimage-addupdinfo "$UPINFO"
+
+echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
 	--compression zstd:level=22 -S23 -B32 \
 	--header uruntime \
 	-i ./AppDir -o ./wayvr_dashboard.AppImage
+
+echo "Generating zsync file..."
+zsyncmake *.AppImage -u *.AppImage


### PR DESCRIPTION
The uruntime makes the appimages a lot smaller: 

![image](https://github.com/user-attachments/assets/a60a5c2e-739d-418d-aeec-12eb74c27920)

I set it up to `-S23` block size, which is slightly slower than the current zstd 14 squashfs appimage.

However the uruntime has the ability to keep the mountpoint, which means if you enable the sed on line 62 and bump the block size to `-S26` the appimage will be 102 MiB and only the very first launch will be slower, all following launches will as fast as a native distro package 👀

So let me know if you want this method. 

I also added the ability to have delta updates with [appimageupdate](https://github.com/AppImageCommunity/AppImageUpdate).

The `.zsync` file has to be released together with the appimage for this to work. 

