### PR TITLE
bundle latest glibc to allow dlopening host libs

### DIFF
--- a/appimage/deb_to_appimage.sh
+++ b/appimage/deb_to_appimage.sh
@@ -51,7 +51,7 @@ mkdir -p ./tmp
 wget "https://archlinux.org/packages/core/"${ARCH}"/glibc/download/" -O ./tmp/glibc.tar.zst
 tar xvf ./tmp/glibc.tar.zst -C ./tmp
 mv -v ./tmp/usr/lib/libc*.so* ./shared/lib
-mv -v ./tmp/usr/lib/libpthreat*.so* ./shared/lib
+mv -v ./tmp/usr/lib/libpthread*.so* ./shared/lib
 mv -v ./tmp/usr/lib/ld-linux*.so* ./shared/lib
 rm -rf ./tmp
 

--- a/appimage/deb_to_appimage.sh
+++ b/appimage/deb_to_appimage.sh
@@ -46,6 +46,15 @@ chmod +x ./lib4bin
         
 rm -rf ./usr
 
+# get latest glibc
+mkdir -p ./tmp
+wget "https://archlinux.org/packages/core/"${ARCH}"/glibc/download/" -O ./tmp/glibc.tar.zst
+tar xvf ./tmp/glibc.tar.zst -C ./tmp
+mv -v ./tmp/usr/lib/libc*.so* ./shared/lib
+mv -v ./tmp/usr/lib/libpthreat*.so* ./shared/lib
+mv -v ./tmp/usr/lib/ld-linux*.so* ./shared/lib
+rm -rf ./tmp
+
 #gstreamer is not used by us
 #/usr/lib/x86_64-linux-gnu/gstreamer-1.0/* \
 


### PR DESCRIPTION
fixes #19 


Another point to run the deb to appimage script on our archlinux docker images btw 👀 [goverlay](https://github.com/benjamimgois/goverlay/releases) recently adopted all of our tools to make a **60 MiB** AppImage that bundles vulkan and Qt.  

