### PR TITLE
Add Homebrew installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Package name: `aur/wayvr-dashboard-git`
 
 [https://aur.archlinux.org/packages/wayvr-dashboard-git](https://aur.archlinux.org/packages/wayvr-dashboard-git)
 
+### Homebrew:
+
+```bash
+brew tap shiloh/atomicxr https://codeberg.org/shiloh/homebrew-atomicxr.git
+brew install wayvr-dashboard
+```
+
 ## Method 3: Via [Releases](https://github.com/olekolek1000/wayvr-dashboard/releases) page:
 
 Unzip the newest WayVR Dashboard, and link the AppImage file in the [wayvr.yaml config file](#assigning-wayvr-dashboard-to-the-wayvr-config-in-wlx-overlay-s)


### PR DESCRIPTION
I've packaged WayVR Dashboard in a [Homebrew tap](https://codeberg.org/shiloh/homebrew-atomicxr) as part of the [AtomicXR](https://codeberg.org/shiloh/atomic-xr) project, so I added it under the package manager method in the README.