### PR TITLE
Update Homebrew Tap URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Package name: `aur/wayvr-dashboard-git`
 ### Homebrew:
 
 ```bash
-brew tap shiloh/atomicxr https://codeberg.org/shiloh/homebrew-atomicxr.git
+brew tap matrixfurry.com/atomicxr https://tangled.sh/@matrixfurry.com/homebrew-atomicxr
 brew install wayvr-dashboard
 ```
 


### PR DESCRIPTION
The AtomicXR Homebrew tap was migrated to Tangled as part of the AtomicXR v1 release.

I am sorry for adding the tap to this README before it was stable. This version of the tap is stable, and the URL will not change again in the future.